### PR TITLE
Update Replit config for pnpm and Nix

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,1 +1,4 @@
 run = "npm start"
+
+[nix]
+channel = "stable-23_05"

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,7 @@
+{ pkgs }: {
+	deps = [
+	pkgs.nodejs-18_x
+    pkgs.nodePackages.typescript-language-server
+    pkgs.nodePackages.pnpm
+	];
+}

--- a/replit.nix
+++ b/replit.nix
@@ -1,7 +1,7 @@
 { pkgs }: {
-	deps = [
-		pkgs.nodejs-18_x
-		pkgs.nodePackages.typescript-language-server
-		pkgs.nodePackages.pnpm
-	];
+  deps = [
+    pkgs.nodejs-18_x
+    pkgs.nodePackages.typescript-language-server
+    pkgs.nodePackages.pnpm
+  ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,7 +1,7 @@
 { pkgs }: {
 	deps = [
-	  pkgs.nodejs-18_x
-    pkgs.nodePackages.typescript-language-server
-    pkgs.nodePackages.pnpm
+		pkgs.nodejs-18_x
+		pkgs.nodePackages.typescript-language-server
+		pkgs.nodePackages.pnpm
 	];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,6 @@
 { pkgs }: {
 	deps = [
-	pkgs.nodejs-18_x
+	  pkgs.nodejs-18_x
     pkgs.nodePackages.typescript-language-server
     pkgs.nodePackages.pnpm
 	];


### PR DESCRIPTION
This PR updates the Replit deployment configuration to support `pnpm`. This includes adding a new file called `replit.nix` and adding `pnpm` to the project. The `Nix channel` is also updated to `stable-23_05`.

Previously, Replit did not support pnpm, which caused an error when deploying the Guest List API. The error message was:
```
> express-event-rsvp-list-api-memory-data-store@1.0.0 start
> tsx index.ts

sh: line 1: tsx: command not found
exit status 127
```
With the changes from this PR, pnpm is now supported by Replit, and the Guest List API works as intended.